### PR TITLE
Add nix ecosystem support

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -128,6 +128,9 @@ class Issue < ApplicationRecord
 
     # Pre-commit hooks
     'pre-commit' => 'pre-commit',
+
+    # Nix
+    'nix' => 'nix',
   }
 
   scope :with_dependency_metadata, -> { where('length(dependency_metadata::text) > 2') }

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -51,7 +51,8 @@ class Package < ApplicationRecord
     'helm' => 'helm',
     'kubernetes' => 'k8s',
     'bazel' => 'bazel',
-    'julia' => 'julia'
+    'julia' => 'julia',
+    'nix' => 'nix'
     # Note: devcontainers, vcpkg, rust-toolchain, submodules, pre-commit have no official PURL type
     # They fall back to ecosystem name via purl_type method
   }.freeze

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -670,6 +670,10 @@ class IssueTest < ActiveSupport::TestCase
     assert_equal 'pre-commit', Issue::DEPENDABOT_ECOSYSTEMS['pre-commit']
   end
 
+  test "DEPENDABOT_ECOSYSTEMS maps nix to nix" do
+    assert_equal 'nix', Issue::DEPENDABOT_ECOSYSTEMS['nix']
+  end
+
   test "parses pre-commit hook bump with label" do
     issue = Issue.new(
       repository: @repository,

--- a/test/models/package_test.rb
+++ b/test/models/package_test.rb
@@ -69,7 +69,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   test "should accept new Dependabot ecosystems" do
-    %w[bazel devcontainers julia vcpkg rust-toolchain].each do |ecosystem|
+    %w[bazel devcontainers julia vcpkg rust-toolchain nix].each do |ecosystem|
       package = Package.new(name: "test-#{ecosystem}-package", ecosystem: ecosystem)
       assert package.valid?, "Expected #{ecosystem} to be valid but got: #{package.errors.full_messages}"
     end


### PR DESCRIPTION
Dependabot now supports Nix version updates: https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/

Adds `nix` to `DEPENDABOT_ECOSYSTEMS` in `Issue` and `ECOSYSTEM_TO_PURL_TYPE` in `Package` so the app can parse and track Nix Dependabot PRs.