### PR TITLE
Fix mobile overflow for long names

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,16 @@
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12) !important;
   }
 }
+
+// Allow flex children that contain long repository/package names to shrink on
+// narrow screens instead of forcing cards wider than the viewport.
+.min-width-0 {
+  min-width: 0;
+}
+
+// Badges often contain package coordinates such as ecosystem:name. Let those
+// wrap on mobile instead of overflowing their card containers.
+.badge {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Fixes #3

## Summary
- adds a `.min-width-0` utility used by existing flex layouts so long repository/package names can shrink on narrow screens
- lets badge text wrap and break anywhere, preventing long package coordinates from forcing mobile overflow

## Validation
- `git diff --check` passed
- Full Rails/style build could not run locally because this repo's lockfile requires Bundler 4.0.10 while the system Ruby/Bundler cannot satisfy it