### PR TITLE
Add GIN index on advisories.packages and use jsonb containment

### DIFF
--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -8,11 +8,11 @@ class Advisory < ApplicationRecord
   after_destroy :clear_issue_advisory_cache
 
   scope :by_severity, ->(severity) { where(severity: severity.upcase) if severity.present? }
-  scope :by_ecosystem, ->(ecosystem) { 
-    where("EXISTS (SELECT 1 FROM jsonb_array_elements(packages) AS pkg WHERE pkg->>'ecosystem' = ?)", ecosystem) if ecosystem.present?
+  scope :by_ecosystem, ->(ecosystem) {
+    where("packages @> ?", [{ ecosystem: ecosystem }].to_json) if ecosystem.present?
   }
   scope :by_package, ->(ecosystem, package_name) {
-    where("EXISTS (SELECT 1 FROM jsonb_array_elements(packages) AS pkg WHERE pkg->>'ecosystem' = ? AND pkg->>'package_name' = ?)", ecosystem, package_name)
+    where("packages @> ?", [{ ecosystem: ecosystem, package_name: package_name }].to_json)
   }
   scope :by_repository_url, ->(url) { where(repository_url: url) if url.present? }
   scope :recent, -> { order(published_at: :desc) }

--- a/db/migrate/20260710153105_add_gin_index_on_advisories_packages.rb
+++ b/db/migrate/20260710153105_add_gin_index_on_advisories_packages.rb
@@ -1,8 +1,13 @@
 class AddGinIndexOnAdvisoriesPackages < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
-  def change
+  def up
+    remove_index :advisories, name: 'index_advisories_on_packages', if_exists: true, algorithm: :concurrently
     add_index :advisories, :packages, using: :gin, opclass: :jsonb_path_ops,
               name: 'index_advisories_on_packages', algorithm: :concurrently
+  end
+
+  def down
+    remove_index :advisories, name: 'index_advisories_on_packages', if_exists: true, algorithm: :concurrently
   end
 end

--- a/db/migrate/20260710153105_add_gin_index_on_advisories_packages.rb
+++ b/db/migrate/20260710153105_add_gin_index_on_advisories_packages.rb
@@ -1,0 +1,8 @@
+class AddGinIndexOnAdvisoriesPackages < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :advisories, :packages, using: :gin, opclass: :jsonb_path_ops,
+              name: 'index_advisories_on_packages', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_053814) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_153105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -43,6 +43,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_053814) do
     t.index ["identifiers"], name: "index_advisories_on_identifiers", using: :gin
     t.index ["issues_count"], name: "index_advisories_on_issues_count"
     t.index ["merge_rate"], name: "index_advisories_on_merge_rate"
+    t.index ["packages"], name: "index_advisories_on_packages", opclass: :jsonb_path_ops, using: :gin
     t.index ["published_at"], name: "index_advisories_on_published_at"
     t.index ["repository_url"], name: "index_advisories_on_repository_url"
     t.index ["severity"], name: "index_advisories_on_severity"

--- a/test/models/advisory_test.rb
+++ b/test/models/advisory_test.rb
@@ -51,6 +51,30 @@ class AdvisoryTest < ActiveSupport::TestCase
       assert_includes Advisory.by_package('npm', 'test-package'), @critical_advisory
       assert_not_includes Advisory.by_package('npm', 'test-package'), @low_advisory
     end
+
+    should 'filter by ecosystem when advisory has multiple packages' do
+      multi = Advisory.create!(
+        uuid: 'test-uuid-multi',
+        packages: [
+          { 'ecosystem' => 'npm', 'package_name' => 'a' },
+          { 'ecosystem' => 'cargo', 'package_name' => 'b' }
+        ]
+      )
+      assert_includes Advisory.by_ecosystem('cargo'), multi
+      assert_includes Advisory.by_package('cargo', 'b'), multi
+      assert_not_includes Advisory.by_ecosystem('cargo'), @critical_advisory
+    end
+
+    should 'not match by_package on ecosystem and name from different array elements' do
+      Advisory.create!(
+        uuid: 'test-uuid-cross',
+        packages: [
+          { 'ecosystem' => 'npm', 'package_name' => 'a' },
+          { 'ecosystem' => 'cargo', 'package_name' => 'b' }
+        ]
+      )
+      assert_empty Advisory.by_package('npm', 'b')
+    end
     
     should 'filter by repository url' do
       assert_includes Advisory.by_repository_url('https://github.com/test/repo'), @critical_advisory


### PR DESCRIPTION
The `by_ecosystem` and `by_package` scopes on `Advisory` unpacked `jsonb_array_elements(packages)` in a lateral subquery, which seq-scans the whole table on every call. These fire on every `packages#show` render (via `show.html.erb`) and every `advisories#index` request. Under crawler load on 07-05/06 the parallel workers for these scans exhausted `/dev/shm` on the postgres container, surfacing as `PG::DiskFull: could not resize shared memory segment`.

This adds a `jsonb_path_ops` GIN index on `advisories.packages` and rewrites both scopes to use `packages @> '[{...}]'` containment. `by_package` becomes a bitmap index scan; `by_ecosystem` may still seq scan for common ecosystems where that's cheaper, but the filter is now a single containment check per row rather than a lateral function scan.

Index is built with `algorithm: :concurrently` so it won't lock the table during deploy.

The infrastructure side of the incident (raising the container's `--shm-size`, blocking the crawler at APISIX) is being handled separately.