### PR TITLE
Return 404 for pagination overflow instead of 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
   before_action :set_cache_headers
 
+  rescue_from Pagy::OverflowError do
+    raise ActiveRecord::RecordNotFound
+  end
+
   after_action lambda {
     request.session_options[:skip] = true
   }

--- a/test/controllers/advisories_controller_test.rb
+++ b/test/controllers/advisories_controller_test.rb
@@ -55,6 +55,16 @@ class AdvisoriesControllerTest < ActionDispatch::IntegrationTest
     assert_match @critical_advisory.title, response.body
     assert_no_match @high_advisory.title, response.body
   end
+
+  test "should return 404 when paging past the end of an empty result set" do
+    get advisories_url(ecosystem: 'nonexistent', page: 3)
+    assert_response :not_found
+  end
+
+  test "should return 200 for page 1 of an empty result set" do
+    get advisories_url(ecosystem: 'nonexistent')
+    assert_response :success
+  end
   
   test "should search by identifier" do
     get advisories_url(q: 'CVE-2023-0001')


### PR DESCRIPTION
`pagy_countless` raises `Pagy::OverflowError` when `page > 1` and the filtered scope has zero rows. Minimal repro: `/advisories?ecosystem=k8s&page=3` — `k8s` matches no advisories, page 3 asks for offset 100, gets nothing, Pagy raises, Rails returns 500.

A crawler is iterating `(ecosystem × page)` combinations across every ecosystem name for packages that don't exist in most of them, so this fires constantly.

Rescue `Pagy::OverflowError` to `ActiveRecord::RecordNotFound` in `ApplicationController` so these render as 404. Covers every paginated action in both the HTML and `/api/v1` controllers.

The 500-response caching and the CF cache purge for `/advisories?*` are being handled in a separate PR.