### PR TITLE
Set Cache-Control: no-store on error responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,7 @@
 class ErrorsController < ApplicationController
+  skip_before_action :set_cache_headers
+  before_action { response.headers['Cache-Control'] = 'no-store' }
+
   def not_found
     respond_to do |format|
       format.html { render status: :not_found }

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -29,6 +29,17 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     assert_match "couldn&#39;t be processed", response.body
   end
 
+  test 'error responses set no-store and no s-maxage' do
+    get '/500'
+    assert_equal 'no-store', response.headers['Cache-Control']
+
+    get '/404'
+    assert_equal 'no-store', response.headers['Cache-Control']
+
+    get '/422'
+    assert_equal 'no-store', response.headers['Cache-Control']
+  end
+
   test 'renders 500 with proper meta tags' do
     get '/500'
     assert_response :internal_server_error


### PR DESCRIPTION
`ErrorsController` inherits `before_action :set_cache_headers` from `ApplicationController`, so 404/422/500 responses were going out with:

```
Cache-Control: public, max-age=300, s-maxage=21600, stale-while-revalidate=21600, stale-if-error=86400
```

During the 07-05/06 postgres `/dev/shm` exhaustion, transient 500s on real URLs got cached at the edge for 6h fresh + 24h stale-if-error, and in browsers for 5m — so users kept seeing errors well after origin recovered.

Skip the inherited callback and set `no-store` on all error responses instead. Applies to 404 as well; a package that doesn't exist yet shouldn't have its 404 cached for 6h.

After deploying, purge `/advisories?*` from the CF cache to clear the 500s already sitting there.