### PR TITLE
Add Dependabot takedown support

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -2,14 +2,14 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
   before_action :find_host
 
   def index
-    @scope = @host.repositories.where.not(owner: nil).group(:owner).count.sort_by{|k,v| -v }
+    @scope = @host.repositories.without_hidden_owner.where.not(owner: nil).group(:owner).count.sort_by{|k,v| -v }
     @pagy, @owners = pagy_array(@scope)
-    @hidden_owners = @host.owners.hidden.pluck(:login).to_set
+    @hidden_owners = @host.owners.hidden.pluck(:login).map(&:downcase).to_set
   end
 
   def show
     @owner = params[:id]
-    owner_record = @host.owners.find_by(login: @owner.downcase)
+    owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
     raise ActiveRecord::RecordNotFound if owner_record&.hidden?
 
     @issues_count = @host.issues.owner(@owner).where(pull_request: false).count
@@ -41,7 +41,7 @@ class Api::V1::OwnersController < Api::V1::ApplicationController
 
   def maintainers
     @owner = params[:id]
-    owner_record = @host.owners.find_by(login: @owner.downcase)
+    owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
     raise ActiveRecord::RecordNotFound if owner_record&.hidden?
 
     @maintainers = @host.issues.owner(@owner).maintainers.group(:user).count.sort_by{|k,v| -v }

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -2,14 +2,14 @@ class OwnersController < ApplicationController
   before_action :find_host
 
   def index
-    @scope = @host.repositories.where.not(owner: nil).group(:owner).count.sort_by{|k,v| -v }
+    @scope = @host.repositories.without_hidden_owner.where.not(owner: nil).group(:owner).count.sort_by{|k,v| -v }
     @pagy, @owners = pagy_array(@scope)
-    @hidden_owners = @host.owners.hidden.pluck(:login).to_set
+    @hidden_owners = @host.owners.hidden.pluck(:login).map(&:downcase).to_set
   end
 
   def show
     @owner = params[:id]
-    owner_record = @host.owners.find_by(login: @owner.downcase)
+    owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
     raise ActiveRecord::RecordNotFound if owner_record&.hidden?
 
     @pull_requests_count = @host.issues.owner(@owner).where(pull_request: true).count
@@ -34,7 +34,7 @@ class OwnersController < ApplicationController
 
   def issues
     @owner = params[:id]
-    owner_record = @host.owners.find_by(login: @owner.downcase)
+    owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
     raise ActiveRecord::RecordNotFound if owner_record&.hidden?
     
     # Get all issues for repositories owned by this owner
@@ -49,7 +49,7 @@ class OwnersController < ApplicationController
 
   def feed
     @owner = params[:id]
-    owner_record = @host.owners.find_by(login: @owner.downcase)
+    owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
     raise ActiveRecord::RecordNotFound if owner_record&.hidden?
     
     # Get recent issues for repositories owned by this owner with pagination

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -523,6 +523,9 @@ class Import < ApplicationRecord
     
     github_host = Host.find_by(name: 'GitHub')
     return nil unless github_host
+
+    hidden_owner = github_host.owners.hidden.where('lower(login) = ?', owner_name.downcase).exists?
+    return nil if hidden_owner
     
     # Use case-insensitive lookup to match the existing index
     existing_repo = Repository.find_by('lower(full_name) = ? AND host_id = ?', repo_name.downcase, github_host.id)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -14,14 +14,25 @@ class Repository < ApplicationRecord
 
   belongs_to :host
 
-  has_many :issues, dependent: :delete_all
+  has_many :issues, dependent: :destroy
 
   validates :full_name, presence: true
 
   after_create :sync_repository_async
 
   scope :active, -> { where(status: nil) }
-  scope :visible, -> { active.where.not(last_synced_at: nil) }
+  scope :without_hidden_owner, -> {
+    where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1
+        FROM owners
+        WHERE owners.host_id = repositories.host_id
+          AND lower(owners.login) = lower(repositories.owner)
+          AND owners.hidden = TRUE
+      )
+    SQL
+  }
+  scope :visible, -> { active.without_hidden_owner.where.not(last_synced_at: nil) }
   scope :created_after, ->(date) { where('created_at > ?', date) }
   scope :updated_after, ->(date) { where('updated_at > ?', date) }
   scope :owner, ->(owner) { where(owner: owner) }
@@ -77,7 +88,7 @@ class Repository < ApplicationRecord
 
   def owner_record
     return nil if owner.blank?
-    host.owners.find_by(login: owner)
+    host.owners.find_by('lower(login) = ?', owner.downcase)
   end
 
   def owner_hidden?
@@ -86,6 +97,8 @@ class Repository < ApplicationRecord
   end
 
   def sync_details
+    return if owner_hidden?
+
     conn = Faraday.new(repos_api_url) do |f|
       f.request :json
       f.request :retry
@@ -228,10 +241,14 @@ class Repository < ApplicationRecord
   end
   
   def sync_repository_async
+    return if owner_hidden?
+
     SyncRepositoryWorker.perform_async(id)
   end
   
   def sync
+    return if owner_hidden?
+
     sync_details
   end
   

--- a/app/views/api/v1/owners/index.json.jbuilder
+++ b/app/views/api/v1/owners/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.array! @owners.reject { |owner, _| @hidden_owners.include?(owner) } do |owner, count|
+json.array! @owners.reject { |owner, _| @hidden_owners.include?(owner.downcase) } do |owner, count|
   json.login owner
   json.repositories_count count
   json.owner_url api_v1_host_owner_url(@host, owner)

--- a/app/views/owners/_owner.html.erb
+++ b/app/views/owners/_owner.html.erb
@@ -1,5 +1,5 @@
 <% name, count = owner %>
-<% return if @hidden_owners&.include?(name) %>
+<% return if @hidden_owners&.include?(name.downcase) %>
 <div class="card mb-3 repository d-flex">
   <div class="card-body pb-1">
     <div class="d-flex">

--- a/lib/tasks/takedown.rake
+++ b/lib/tasks/takedown.rake
@@ -1,0 +1,47 @@
+namespace :takedown do
+  desc "Hide a user and remove their repositories. LOGIN=username [HOST=GitHub]"
+  task hide_user: :environment do
+    login = ENV['LOGIN']
+    host_name = ENV['HOST'] || 'GitHub'
+    abort "LOGIN is required" if login.blank?
+
+    host = Host.find_by_name(host_name)
+    abort "Host #{host_name} not found" if host.nil?
+
+    owner = nil
+    repository_count = 0
+    issue_count = 0
+
+    ActiveRecord::Base.transaction do
+      owner = host.owners.find_by('lower(login) = ?', login.downcase)
+      owner ||= host.owners.create!(login: login.downcase)
+      owner.update!(hidden: true)
+
+      repositories = host.repositories.where('lower(owner) = ?', login.downcase)
+      repository_count = repositories.count
+      issue_count = Issue.where(repository_id: repositories.select(:id)).count
+      repositories.find_each(&:destroy!)
+    end
+
+    puts "[dependabot] hidden owner #{host.name}/#{owner.login}"
+    puts "[dependabot] destroyed #{repository_count} repositories and #{issue_count} issues for #{host.name}/#{login}"
+  end
+
+  desc "Report what exists for a user. LOGIN=username [HOST=GitHub]"
+  task report: :environment do
+    login = ENV['LOGIN']
+    host_name = ENV['HOST'] || 'GitHub'
+    abort "LOGIN is required" if login.blank?
+
+    host = Host.find_by_name(host_name)
+    abort "Host #{host_name} not found" if host.nil?
+
+    owner = host.owners.find_by('lower(login) = ?', login.downcase)
+    repositories = host.repositories.where('lower(owner) = ?', login.downcase)
+    repository_count = repositories.count
+    issue_count = Issue.where(repository_id: repositories.select(:id)).count
+    state = owner ? (owner.hidden? ? 'hidden' : 'visible') : 'none'
+
+    puts "[dependabot] #{host.name}/#{login}: owner=#{state} repositories=#{repository_count} issues=#{issue_count}"
+  end
+end

--- a/test/controllers/owners_controller_test.rb
+++ b/test/controllers/owners_controller_test.rb
@@ -120,7 +120,7 @@ class OwnersControllerTest < ActionDispatch::IntegrationTest
   test "hidden owner show returns 404" do
     host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
     repository = Repository.create!(host: host, full_name: 'hidden-org/repo', owner: 'hidden-org', issues_count: 5)
-    Owner.create!(host: host, login: 'hidden-org', hidden: true)
+    Owner.create!(host: host, login: 'HIDDEN-ORG', hidden: true)
 
     get host_owner_path(host, 'hidden-org')
     assert_response :not_found

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -197,7 +197,7 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
   test "should return 404 for repository with hidden owner" do
     host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
     repository = Repository.create!(host: host, full_name: 'hidden-org/repo', owner: 'hidden-org')
-    Owner.create!(host: host, login: 'hidden-org', hidden: true)
+    Owner.create!(host: host, login: 'HIDDEN-ORG', hidden: true)
 
     get host_repository_path(host, repository)
     assert_response :not_found

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -128,6 +128,19 @@ class ImportTest < ActiveSupport::TestCase
     assert_equal 'open', created_issue.effective_state
   end
 
+  test "does not import repositories for a hidden owner" do
+    repository = Repository.create!(
+      host: @host,
+      full_name: "Hidden-Org/existing",
+      owner: "Hidden-Org"
+    )
+    Owner.create!(host: @host, login: "hidden-org", hidden: true)
+
+    assert_nil Import.send(:find_or_create_repository, repository.full_name)
+    assert_nil Import.send(:find_or_create_repository, "HIDDEN-ORG/new")
+    assert_not Repository.exists?(host: @host, full_name: "HIDDEN-ORG/new")
+  end
+
   test "processes different dependabot user variations" do
     # Test different dependabot user formats
     test_data = [

--- a/test/models/repository_owner_test.rb
+++ b/test/models/repository_owner_test.rb
@@ -20,8 +20,28 @@ class RepositoryOwnerTest < ActiveSupport::TestCase
     assert_equal true, @repository.owner_hidden?
   end
 
+  test "owner_hidden? matches owner login case-insensitively" do
+    Owner.create!(host: @host, login: 'TEST', hidden: true)
+    assert_equal true, @repository.owner_hidden?
+  end
+
   test "owner_hidden? returns false for nil hidden owner" do
     Owner.create!(host: @host, login: 'test', hidden: nil)
     assert_equal false, @repository.owner_hidden?
+  end
+
+  test "visible excludes repositories belonging to hidden owners" do
+    @repository.update!(last_synced_at: Time.current)
+    Owner.create!(host: @host, login: 'TEST', hidden: true)
+
+    assert_not_includes Repository.visible, @repository
+  end
+
+  test "hidden owner repositories are not enqueued for sync" do
+    Owner.create!(host: @host, login: 'TEST', hidden: true)
+
+    assert_no_difference -> { SyncRepositoryWorker.jobs.size } do
+      @repository.sync_repository_async
+    end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -81,5 +81,14 @@ class RepositoryTest < ActiveSupport::TestCase
       @repository.reload
       assert_nil @repository.last_synced_at
     end
+
+    should "not request details for a hidden owner" do
+      Owner.create!(host: @host, login: "OWNER", hidden: true)
+
+      @repository.sync_details
+
+      assert_not_requested :get, @repository.repos_api_url
+      assert_nil @repository.reload.last_synced_at
+    end
   end
 end

--- a/test/tasks/takedown_rake_test.rb
+++ b/test/tasks/takedown_rake_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+require "rake"
+
+class TakedownRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("takedown:hide_user")
+    ENV.delete("HOST")
+    ENV.delete("LOGIN")
+  end
+
+  teardown do
+    ENV.delete("HOST")
+    ENV.delete("LOGIN")
+  end
+
+  test "hide_user hides an owner and removes their repositories and issues" do
+    host = Host.create!(name: "GitHub", url: "https://github.com", kind: "github")
+    owner = Owner.create!(host: host, login: "Target-Org")
+    repository = Repository.create!(
+      host: host,
+      full_name: "target-org/project",
+      owner: "target-org"
+    )
+    other_repository = Repository.create!(
+      host: host,
+      full_name: "other-org/project",
+      owner: "other-org"
+    )
+    issue = Issue.create!(
+      repository: repository,
+      host: host,
+      number: 1,
+      title: "Bump example",
+      state: "open",
+      pull_request: true,
+      uuid: "target-issue",
+      user: "dependabot[bot]"
+    )
+    package = Package.create!(ecosystem: "rubygems", name: "example")
+    advisory = Advisory.create!(uuid: "target-advisory")
+    IssuePackage.create!(issue: issue, package: package)
+    IssueAdvisory.create!(issue: issue, advisory: advisory)
+    ENV["LOGIN"] = "TARGET-ORG"
+
+    output, = capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    assert owner.reload.hidden?
+    assert_not Repository.exists?(repository.id)
+    assert Repository.exists?(other_repository.id)
+    assert_not Issue.exists?(issue.id)
+    assert_not IssuePackage.exists?(issue_id: issue.id)
+    assert_not IssueAdvisory.exists?(issue_id: issue.id)
+    assert_equal 0, package.reload.issues_count
+    assert_equal 0, advisory.reload.issues_count
+    assert_includes output, "[dependabot] hidden owner GitHub/Target-Org"
+    assert_includes output, "[dependabot] destroyed 1 repositories and 1 issues"
+  end
+
+  test "hide_user creates a hidden tombstone for an unknown owner" do
+    Host.create!(name: "GitHub", url: "https://github.com", kind: "github")
+    ENV["LOGIN"] = "Missing-Owner"
+
+    capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    owner = Owner.find_by(login: "missing-owner")
+    assert owner.hidden?
+  end
+
+  test "hide_user aborts without LOGIN" do
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["takedown:hide_user"].execute }
+    end
+  end
+
+  test "report describes a hidden owner and their data" do
+    host = Host.create!(name: "GitHub", url: "https://github.com", kind: "github")
+    Owner.create!(host: host, login: "Hidden-Owner", hidden: true)
+    repository = Repository.create!(
+      host: host,
+      full_name: "hidden-owner/project",
+      owner: "hidden-owner"
+    )
+    Issue.create!(
+      repository: repository,
+      host: host,
+      number: 1,
+      title: "Bump example",
+      state: "open",
+      pull_request: true,
+      uuid: "report-issue",
+      user: "dependabot[bot]"
+    )
+    ENV["LOGIN"] = "HIDDEN-OWNER"
+
+    output, = capture_io { Rake::Task["takedown:report"].execute }
+
+    assert_includes output, "[dependabot] GitHub/HIDDEN-OWNER: owner=hidden repositories=1 issues=1"
+  end
+end


### PR DESCRIPTION
Adds Dependabot takedown and report tasks. Hidden owners are excluded from imports, sync jobs, and public listings, while takedowns remove repositories and associated issue data and retain an owner tombstone.