### PR TITLE
Fix repository sync calls

### DIFF
--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     @repository = @host.repositories.find_by('lower(full_name) = ?', path.downcase)
     if @repository
       raise ActiveRecord::RecordNotFound if @repository.owner_hidden?
-      @repository.sync_async(request.remote_ip) unless @repository.last_synced_at.present? && @repository.last_synced_at > 1.day.ago
+      @repository.sync_repository_async unless @repository.last_synced_at.present? && @repository.last_synced_at > 1.day.ago
       redirect_to api_v1_host_repository_path(@host, @repository)
     else
       raise ActiveRecord::RecordNotFound, "Repository not found for URL: #{url}"
@@ -49,7 +49,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:id].downcase)
     raise ActiveRecord::RecordNotFound if @repository.owner_hidden?
     if @repository
-      @repository.sync_async
+      @repository.sync_repository_async
     end
     render json: { message: 'pong' }
   end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -12,7 +12,7 @@ class RepositoriesController < ApplicationController
     @repository = @host.repositories.find_by('lower(full_name) = ?', path.downcase)
     if @repository
       raise ActiveRecord::RecordNotFound if @repository.owner_hidden?
-      @repository.sync_async(request.remote_ip) unless @repository.last_synced_at.present? && @repository.last_synced_at > 1.day.ago
+      @repository.sync_repository_async unless @repository.last_synced_at.present? && @repository.last_synced_at > 1.day.ago
       redirect_to host_repository_path(@host, @repository)
     else
       raise ActiveRecord::RecordNotFound

--- a/test/controllers/api/v1/repositories_controller_test.rb
+++ b/test/controllers/api/v1/repositories_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class Api::V1::RepositoriesControllerTest < ActionDispatch::IntegrationTest
+  test "lookup syncs a stale repository" do
+    host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
+    repository = Repository.create!(host: host, full_name: 'test/lookup-repo', last_synced_at: 2.days.ago)
+    Repository.any_instance.expects(:sync_repository_async)
+
+    get api_v1_repositories_lookup_path(url: 'https://github.com/test/lookup-repo')
+
+    assert_redirected_to api_v1_host_repository_path(host, repository)
+  end
+end

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -38,7 +38,7 @@ class CacheHeadersTest < ActionDispatch::IntegrationTest
   test "API ping endpoint does not set cache headers" do
     host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
     repository = Repository.create!(host: host, full_name: 'test/ping-repo')
-    Repository.any_instance.expects(:sync_async)
+    Repository.any_instance.expects(:sync_repository_async)
 
     get ping_api_v1_host_repository_url(host, repository), as: :json
     assert_response :success

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -209,4 +209,14 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
     get host_repository_path(host, 'nonexistent/repo')
     assert_response :not_found
   end
+
+  test "lookup syncs a stale repository" do
+    host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
+    repository = Repository.create!(host: host, full_name: 'test/lookup-repo', last_synced_at: 2.days.ago)
+    Repository.any_instance.expects(:sync_repository_async)
+
+    get lookup_repositories_path(url: 'https://github.com/test/lookup-repo')
+
+    assert_redirected_to host_repository_path(host, repository)
+  end
 end


### PR DESCRIPTION
Replace stale `Repository#sync_async` calls with `sync_repository_async` in repository lookup and ping endpoints. Add request coverage for stale repository lookups and update ping coverage.